### PR TITLE
macOS compile patches

### DIFF
--- a/gpst.c
+++ b/gpst.c
@@ -99,7 +99,8 @@ int gpst_xml_or_error(struct openconnect_info *vpninfo, int result, char *respon
 		   thisForm.inputStr.value = ""; */
 		if ((err = strstr(response, "respMsg = \"")) != NULL) {
 			err += 11;
-			errlen = strchrnul(err, ';') - err - 1;
+			const char *semicolon = strchr(err, ';');
+			errlen = semicolon ? semicolon - err - 1 : strlen(err) - 1;
 			vpn_progress(vpninfo, PRG_ERR,
 				     _("%.*s\n"), errlen, err);
 			goto out;


### PR DESCRIPTION
Mac (like FreeBSD) doesn’t have struct iphdr, struct icmphdr, and strchrnul.
These patches allow it to compile.
Unfortunately, my company's VPN does not use ESP, so I cannot properly test this.

Thanks for your great work!