### PR TITLE
Add support for "Challenge" login

### DIFF
--- a/auth-globalprotect.c
+++ b/auth-globalprotect.c
@@ -134,8 +134,6 @@ int gpst_obtain_cookie(struct openconnect_info *vpninfo)
 
 	/* Ask the user to fill in the auth form; repeat as necessary */
 	do {
-		free(xml_buf);
-		buf_truncate(request_body);
 
 		/* process static auth form (username and password) */
 		result = process_auth_form(vpninfo, form);
@@ -151,6 +149,7 @@ int gpst_obtain_cookie(struct openconnect_info *vpninfo)
 		}
 
 		/* submit login request */
+		buf_truncate(request_body);
 		buf_append(request_body, "jnlpReady=jnlpReady&ok=Login&direct=yes&clientVer=4100&prot=https:");
 		append_opt(request_body, "server", vpninfo->hostname);
 		append_opt(request_body, "computer", vpninfo->localname);

--- a/globalprotect-challenge-login.py
+++ b/globalprotect-challenge-login.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python
+
+from __future__ import print_function
+try:
+    import http.client as http_client
+except ImportError:
+    # Python 2
+    import httplib as http_client
+    input = raw_input
+
+import requests
+import argparse
+import getpass
+import os, re
+from sys import stderr
+
+p = argparse.ArgumentParser()
+p.add_argument('-v','--verbose', default=0, action='count')
+p.add_argument('gateway', help='Hostname of GlobalProtect gateway')
+g = p.add_argument_group('Login credentials')
+g.add_argument('-u', '--user', help='Username (will prompt if unspecified)')
+g.add_argument('-p', '--password', help='Password (will prompt if unspecified)')
+g.add_argument('--cert', help='PEM file containing client certificate (and optionally private key)')
+g.add_argument('--key', help='PEM file containing client private key (if not included in same file as certificate)')
+g.add_argument('--no-verify', dest='verify', action='store_false', default=True, help='Ignore invalid server certificate')
+args = p.parse_args()
+
+if args.cert and args.key:
+    cert = (args.cert, args.key)
+elif args.cert:
+    cert = (args.cert)
+elif args.key:
+    p.error('--key specified without --cert')
+else:
+    cert = None
+
+s = requests.Session()
+s.headers['User-Agent'] = 'PAN GlobalProtect'
+s.cert = cert
+
+if args.verbose:
+    http_client.HTTPConnection.debuglevel = 1
+
+user, password, inputStr = args.user, args.password, ''
+login = 'https://{}/ssl-vpn/login.esp'.format(args.gateway)
+hostname = os.uname()[1]
+
+while True:
+    if not user:
+        user = input('Username: ')
+    if not password:
+        password = getpass.getpass('Password: ')
+
+    print("Posting login request to: %s" % login)
+    form = dict(user=user, passwd=password, inputStr=inputStr,
+                jnlpReady='jnlpReady', ok='Login', direct='yes', # required
+                clientVer=4100, server=args.gateway, prot='https:', computer=hostname # optional but might affect behavior
+    )
+    res = s.post(login, form, verify=args.verify)
+
+    unknown = False
+    if res.headers['Content-Type']=='text/html':
+        # parse JavaScript-y bits
+        m = re.match(r'''\n*var respStatus = "(.*)";\nvar respMsg = "(.*)";\n*thisForm.inputStr.value = "(.*)";\n*''', res.text)
+        if m:
+            respStatus, respMsg, value = m.groups()
+            if respStatus=='Challenge':
+                print('=> Challenge with inputStr=%r: %s' % (value, respMsg))
+                password = None
+                inputStr = value
+            else:
+                print('=> %s with inputStr=%r: %s' % (respStatus, inputStr, respMsg))
+                break
+        else:
+            unknown = True
+    elif res.status_code == 200:
+        print('=> Success')
+        print(res.text)
+        break
+    else:
+        unknown = True
+
+    if unknown:
+        print('Got unknown response: %r', res.text)
+        res.raise_for_status()

--- a/gpst.c
+++ b/gpst.c
@@ -66,12 +66,86 @@ static int xmlnode_get_text(xmlNode *xml_node, const char *name, const char **va
 	return 0;
 }
 
+/* Parse this JavaScript-y mess:
+
+	"var respStatus = \"<status>\";\n"
+	"var respMsg = \"<prompt>\";\n"
+	"thisForm.inputStr.value = "<inputStr>";\n"
+*/
+int gpst_scrape_javascript(char *javascript, char **prompt, char **inputStr)
+{
+	const char *start, *end = javascript;
+	int status;
+
+	const char *pre_status = "var respStatus = \"",
+	           *pre_prompt = "var respMsg = \"",
+	           *pre_inputStr = "thisForm.inputStr.value = \"";
+
+	/* Status */
+	while (isspace(*end))
+		end++;
+	if (strncmp(end, pre_status, strlen(pre_status)))
+		goto err;
+
+	start = end+strlen(pre_status);
+	end = strchr(start, '\n');
+	if (!end || end[-1] != ';' || end[-2] != '"')
+		goto err;
+
+	if (!strncmp(start, "Challenge", 8))    status = 2;
+	else if (!strncmp(start, "Error", 5))   status = 1;
+	else if (!strncmp(start, "Success", 7)) status = 0;
+	else                                    goto err;
+
+	/* Prompt */
+	while (isspace(*end))
+		end++;
+	if (strncmp(end, pre_prompt, strlen(pre_prompt)))
+		goto err;
+
+	start = end+strlen(pre_prompt);
+	end = strchr(start, '\n');
+	if (!end || end[-1] != ';' || end[-2] != '"')
+		goto err;
+
+	if (prompt)
+		*prompt = strndup(start, end-start-2);
+
+	/* inputStr */
+	while (isspace(*end))
+		end++;
+	if (strncmp(end, pre_inputStr, strlen(pre_inputStr)))
+		goto err2;
+
+	start = end+strlen(pre_inputStr);
+	end = strchr(start, '\n');
+	if (!end || end[-1] != ';' || end[-2] != '"')
+		goto err2;
+
+	if (inputStr)
+		*inputStr = strndup(start, end-start-2);
+
+	while (isspace(*end))
+		end++;
+	if (*end != '\0')
+		goto err3;
+
+	return status;
+
+err3:
+	if (inputStr) free((void *)inputStr);
+err2:
+	if (prompt) free((void *)prompt);
+err:
+	return -EINVAL;
+}
+
 int gpst_xml_or_error(struct openconnect_info *vpninfo, int result, char *response,
-		      int (*xml_cb)(struct openconnect_info *, xmlNode *xml_node))
+					  int (*xml_cb)(struct openconnect_info *, xmlNode *xml_node),
+					  char **prompt, char **inputStr)
 {
 	xmlDocPtr xml_doc;
 	xmlNode *xml_node;
-	int errlen;
 	const char *err;
 
 	/* custom error codes returned by /ssl-vpn/login.esp and maybe others */
@@ -93,21 +167,32 @@ int gpst_xml_or_error(struct openconnect_info *vpninfo, int result, char *respon
 	xml_doc = xmlReadMemory(response, strlen(response), "noname.xml", NULL,
 				XML_PARSE_NOERROR);
 	if (!xml_doc) {
-		/* nope, but maybe it looks like this JavaScript-y blob:
-		   var respStatus = "Error";
-		   var respMsg = "<want this part>";
-		   thisForm.inputStr.value = ""; */
-		if ((err = strstr(response, "respMsg = \"")) != NULL) {
-			err += 11;
-			errlen = (strchr(err, ';') ? : err + strlen(err)) - err - 1;
-			vpn_progress(vpninfo, PRG_ERR,
-				     _("%.*s\n"), errlen, err);
-			goto out;
+		char *p, *i;
+		result = gpst_scrape_javascript(response, &p, &i);
+		switch (result) {
+		case 0:
+			vpn_progress(vpninfo, PRG_ERR, _("Success: %s\n"), p);
+			break;
+		case 1:
+			vpn_progress(vpninfo, PRG_ERR, _("%s\n"), p);
+			break;
+		case 2:
+			vpn_progress(vpninfo, PRG_ERR, _("Challenge: %s\n"), p);
+			if (prompt && inputStr) {
+				*prompt=p;
+				*inputStr=i;
+				return 2;
+			}
+			break;
+		default:
+			goto bad_xml;
 		}
-		goto bad_xml;
+		free((char *)p);
+		free((char *)i);
+		goto out;
 	}
 
-        xml_node = xmlDocGetRootElement(xml_doc);
+	xml_node = xmlDocGetRootElement(xml_doc);
 
 	/* is it <response status="error"><error>..</error></response> ? */
 	if (xmlnode_is_named(xml_node, "response")
@@ -370,7 +455,7 @@ static int gpst_get_config(struct openconnect_info *vpninfo)
 		goto out;
 
 	/* parse getconfig result */
-	result = gpst_xml_or_error(vpninfo, result, xml_buf, gpst_parse_config_xml);
+	result = gpst_xml_or_error(vpninfo, result, xml_buf, gpst_parse_config_xml, NULL, NULL);
 	if (result)
 		return result;
 

--- a/main.c
+++ b/main.c
@@ -1924,7 +1924,7 @@ static int process_auth_form_cb(void *_vpninfo,
 
 		} else if (opt->type == OC_FORM_OPT_TEXT) {
 			if (username &&
-			    !strcmp(opt->name, "username")) {
+			    (!strcmp(opt->name, "username") || opt->flags & OC_FORM_OPT_FILL_USERNAME)) {
 				opt->_value = username;
 				username = NULL;
 			} else {
@@ -1937,7 +1937,7 @@ static int process_auth_form_cb(void *_vpninfo,
 
 		} else if (opt->type == OC_FORM_OPT_PASSWORD) {
 			if (password &&
-			    !strcmp(opt->name, "password")) {
+			    (!strcmp(opt->name, "password") || opt->flags & OC_FORM_OPT_FILL_PASSWORD)) {
 				opt->_value = password;
 				password = NULL;
 			} else {

--- a/openconnect-internal.h
+++ b/openconnect-internal.h
@@ -864,8 +864,10 @@ void gpst_common_headers(struct openconnect_info *vpninfo, struct oc_text_buf *b
 int gpst_bye(struct openconnect_info *vpninfo, const char *reason);
 
 /* gpst.c */
+int gpst_scrape_javascript(char *javascript, char **prompt, char **inputStr);
 int gpst_xml_or_error(struct openconnect_info *vpninfo, int result, char *response,
-		      int (*xml_cb)(struct openconnect_info *, xmlNode *xml_node));
+					  int (*xml_cb)(struct openconnect_info *, xmlNode *xml_node),
+					  char **prompt, char **inputStr);
 int gpst_setup(struct openconnect_info *vpninfo);
 int gpst_mainloop(struct openconnect_info *vpninfo, int *timeout);
 

--- a/openconnect-internal.h
+++ b/openconnect-internal.h
@@ -864,7 +864,6 @@ void gpst_common_headers(struct openconnect_info *vpninfo, struct oc_text_buf *b
 int gpst_bye(struct openconnect_info *vpninfo, const char *reason);
 
 /* gpst.c */
-int gpst_scrape_javascript(char *javascript, char **prompt, char **inputStr);
 int gpst_xml_or_error(struct openconnect_info *vpninfo, int result, char *response,
 					  int (*xml_cb)(struct openconnect_info *, xmlNode *xml_node),
 					  char **prompt, char **inputStr);

--- a/openconnect.h
+++ b/openconnect.h
@@ -187,6 +187,8 @@ extern "C" {
 
 #define OC_FORM_OPT_IGNORE		0x0001
 #define OC_FORM_OPT_NUMERIC		0x0002
+#define OC_FORM_OPT_FILL_USERNAME	0x0004
+#define OC_FORM_OPT_FILL_PASSWORD	0x0008
 
 /* char * fields are static (owned by XML parser) and don't need to be
    freed by the form handling code — except for value, which for TEXT


### PR DESCRIPTION
This is apparently the way that GlobalProtect does secondary login forms, such as for an OTP sent by SMS.

Response to initial login is this:

```javascript
var respStatus = "Challenge";
var respMsg = "Enter the one-time password sent by SMS.";
thisForm.inputStr.value = "deadbeef";
```

User has to fill out a second form, and login request is resubmitted with `user=<username>&password=<response>&inputStr=deadbeef`.

Python version has been confirmed working by one user.