### PR TITLE
Add support for connection via PAN GlobalProtect portal servers

### DIFF
--- a/auth-globalprotect.c
+++ b/auth-globalprotect.c
@@ -196,17 +196,17 @@ gateways:
 	}
 
 	/* process static auth form to select gateway */
-	form.opts = (struct oc_form_opt *)opt;
+	form.authgroup_opt = opt;
 	result = process_auth_form(vpninfo, &form);
-	if (result)
+	if (result != OC_FORM_RESULT_NEWGROUP)
 		goto out;
 
 	/* redirect to the gateway (no-op if it's the same host) */
-	if ((vpninfo->redirect_url = malloc(strlen(opt->form._value) + 9)) == NULL) {
+	if ((vpninfo->redirect_url = malloc(strlen(vpninfo->authgroup) + 9)) == NULL) {
 		result = -ENOMEM;
 		goto out;
 	}
-	sprintf(vpninfo->redirect_url, "https://%s", opt->form._value);
+	sprintf(vpninfo->redirect_url, "https://%s", vpninfo->authgroup);
 	result = handle_redirect(vpninfo);
 
 out:

--- a/auth-globalprotect.c
+++ b/auth-globalprotect.c
@@ -176,7 +176,6 @@ static int gpst_gateway_login(struct openconnect_info *vpninfo)
 
 	/* Ask the user to fill in the auth form; repeat as necessary */
 	do {
-		free(xml_buf);
 		buf_truncate(request_body);
 
 		/* process static auth form (username and password) */

--- a/auth-globalprotect.c
+++ b/auth-globalprotect.c
@@ -276,10 +276,10 @@ int gpst_obtain_cookie(struct openconnect_info *vpninfo)
 {
 	int result;
 
-	if (vpninfo->urlpath && !strncmp(vpninfo->urlpath, "global-protect", 14)) {
+	if (vpninfo->urlpath && !strcmp(vpninfo->urlpath, "portal")) {
 		/* assume the server is a portal */
 		return gpst_login(vpninfo, 1);
-	} else if (vpninfo->urlpath && !strncmp(vpninfo->urlpath, "ssl-vpn", 7)) {
+	} else if (vpninfo->urlpath && !strcmp(vpninfo->urlpath, "gateway")) {
 		/* assume the server is a gateway */
 		return gpst_login(vpninfo, 0);
 	} else {

--- a/gpst.c
+++ b/gpst.c
@@ -228,7 +228,7 @@ out:
 			vpn_progress(vpninfo, PRG_ERR, "%s\n", err);
 			result = -EINVAL;
 		}
-		free(err);
+		free((void *)err);
 	}
 	if (xml_doc)
 		xmlFreeDoc(xml_doc);


### PR DESCRIPTION
This PR adds support for PAN GlobalProtect ["portal" servers](/dlenski/openconnect/blob/globalprotect/README.md#portal-vs-gateway-servers) in addition to "gateway" servers.

* Connect to a GP VPN via a portal server:

```sh
$ openconnect --protocol=gp vpn.company.com/portal
...
2 gateway servers available:
  Headquarters (vpn-gwhq.company.com)
  Branch (vpn-gwbr.company.com)
Please select GlobalProtect gateway.
GATEWAY: [Headquarters|Branch]:
...
```
* Connect via a portal server, choosing a specific gateway:
```sh
$ openconnect --protocol=gp --authgroup=Headquarters vpn.company.com/portal
```
* Connect via a gateway server:
```sh
$ openconnect --protocol=gp vpn.company.com/gateway
```
* Connect with autodetection (try as gateway first, portal second):
```sh
$ openconnect --protocol=gp vpn.company.com
```