### PR TITLE
Support for different gateway address

### DIFF
--- a/esp.c
+++ b/esp.c
@@ -172,7 +172,7 @@ int esp_send_probes_gp(struct openconnect_info *vpninfo)
 		iph->ip_ttl = 64; /* hops */
 		iph->ip_p = 1; /* ICMP */
 		iph->ip_src.s_addr = inet_addr(vpninfo->ip_info.addr);
-		iph->ip_dst.s_addr = inet_addr(vpninfo->ip_info.gateway_addr);
+		iph->ip_dst.s_addr = inet_addr(vpninfo->ip_info.gateway_addr_gp);
 		iph->ip_sum = csum((uint16_t *)iph, sizeof(*iph)/2);
 
 		/* ICMP echo request */
@@ -183,8 +183,11 @@ int esp_send_probes_gp(struct openconnect_info *vpninfo)
 		icmph->icmp_cksum = csum((uint16_t *)icmph, (ICMP_MINLEN+sizeof(magic))/2);
 
 		pktlen = encrypt_esp_packet(vpninfo, pkt);
-		if (pktlen >= 0)
+		if (pktlen >= 0){
+			vpn_progress(vpninfo, PRG_TRACE, _("Sending ESP ICMP requests to : %s (%d)\n"),
+				     vpninfo->ip_info.gateway_addr_gp,seq);
 			send(vpninfo->dtls_fd, (void *)&pkt->esp, pktlen, 0);
+		}
 	}
 
 	free(pkt);
@@ -203,7 +206,7 @@ int esp_catch_probe_gp(struct openconnect_info *vpninfo, struct pkt *pkt)
 {
 	return ( pkt->len >= 21
 		 && pkt->data[9]==1 /* IPv4 protocol field == ICMP */
-		 && *((uint32_t *)(pkt->data + 12)) == inet_addr(vpninfo->ip_info.gateway_addr) /* source == gateway */
+		 && *((uint32_t *)(pkt->data + 12)) == inet_addr(vpninfo->ip_info.gateway_addr_gp) /* source == gateway */
 		 && pkt->data[20]==0 /* ICMP reply */ );
 }
 

--- a/gpst.c
+++ b/gpst.c
@@ -360,6 +360,7 @@ static int gpst_parse_config_xml(struct openconnect_info *vpninfo, xmlNode *xml_
 	for (xml_node = xml_node->children; xml_node; xml_node=xml_node->next) {
 		xmlnode_get_text(xml_node, "ip-address", &vpninfo->ip_info.addr);
 		xmlnode_get_text(xml_node, "netmask", &vpninfo->ip_info.netmask);
+		xmlnode_get_text(xml_node, "gw-address", &vpninfo->ip_info.gateway_addr_gp);
 
 		if (!xmlnode_get_text(xml_node, "mtu", &s)) {
 			vpninfo->ip_info.mtu = atoi(s);

--- a/openconnect.h
+++ b/openconnect.h
@@ -261,6 +261,10 @@ struct oc_ip_info {
 	struct oc_split_include *split_includes;
 	struct oc_split_include *split_excludes;
 
+	/* Needed if the gateway address presented by the global protect
+	 * gateway portal is not the same as the actual portal. */
+	const char *gateway_addr_gp;
+
 	/* The elements above this line come from server-provided CSTP headers,
 	 * so they should be handled with caution.  gateway_addr is generated
 	 * locally from getnameinfo(). */
@@ -410,7 +414,7 @@ int openconnect_init_ssl(void);
 const char *openconnect_get_cstp_cipher(struct openconnect_info *);
 const char *openconnect_get_dtls_cipher(struct openconnect_info *);
 
-/* These return a descriptive string of the compression algorithm 
+/* These return a descriptive string of the compression algorithm
  * in use (LZS, LZ4, ...). If no compression then NULL is returned. */
 const char *openconnect_get_cstp_compression(struct openconnect_info *);
 const char *openconnect_get_dtls_compression(struct openconnect_info *);


### PR DESCRIPTION
- This commit simply makes the openconnect global protect protocol to work when
  the global protect portal presents a gateway address that is not the same as
  the actual portal. This is done by parsing the `<gw-address>-field` of the xml-
  config received by the server and save it to the new gateway_addr_gp variable
  in the ip_info struct. This is then used as the destination of the esp icmp-
  packets.

Not really sure if this is correct or not, nor if this is the right approach, what I do know though is that I spend quite a lot of time debugging it which concluded in this patch. And as far as I'm concerned it works is expected :sweat_smile: 

The reason I noticed this was because when I connected I never got the IPSEC tunnel - I always ended up connecting over HTTPS. This resulted in a quite "laggy" behavior and frequent disconnects. So I started debugging this and noticed that the only difference between the global protect mac client and openconnect was that the destination of the ICMP-packets for setting up the IPSEC-tunnel was different. In openconnect the destination was the portal - not the gateway address given in the xml-config. So, as stated in the commit message this commit simply parses that address and uses that instead as destination of the ICMP packets, which seems reasonable. 

Any thoughts ?