### PR TITLE
Allow ESP ping address to be distinct from gateway external IP

### DIFF
--- a/esp.c
+++ b/esp.c
@@ -172,7 +172,7 @@ int esp_send_probes_gp(struct openconnect_info *vpninfo)
 		iph->ip_ttl = 64; /* hops */
 		iph->ip_p = 1; /* ICMP */
 		iph->ip_src.s_addr = inet_addr(vpninfo->ip_info.addr);
-		iph->ip_dst.s_addr = inet_addr(vpninfo->ip_info.gateway_addr);
+		iph->ip_dst.s_addr = inet_addr(vpninfo->ip_info.gateway_addr_gp);
 		iph->ip_sum = csum((uint16_t *)iph, sizeof(*iph)/2);
 
 		/* ICMP echo request */
@@ -183,8 +183,11 @@ int esp_send_probes_gp(struct openconnect_info *vpninfo)
 		icmph->icmp_cksum = csum((uint16_t *)icmph, (ICMP_MINLEN+sizeof(magic))/2);
 
 		pktlen = encrypt_esp_packet(vpninfo, pkt);
-		if (pktlen >= 0)
+		if (pktlen >= 0){
+			vpn_progress(vpninfo, PRG_TRACE, _("Sending ESP ICMP requests to : %s (%d)\n"),
+				     vpninfo->ip_info.gateway_addr_gp,seq);
 			send(vpninfo->dtls_fd, (void *)&pkt->esp, pktlen, 0);
+		}
 	}
 
 	free(pkt);
@@ -203,7 +206,7 @@ int esp_catch_probe_gp(struct openconnect_info *vpninfo, struct pkt *pkt)
 {
 	return ( pkt->len >= 21
 		 && pkt->data[9]==1 /* IPv4 protocol field == ICMP */
-		 && *((uint32_t *)(pkt->data + 12)) == inet_addr(vpninfo->ip_info.gateway_addr) /* source == gateway */
+		 && *((uint32_t *)(pkt->data + 12)) == inet_addr(vpninfo->ip_info.gateway_addr_gp) /* source == gateway */
 		 && pkt->data[20]==0 /* ICMP reply */ );
 }
 

--- a/gpst.c
+++ b/gpst.c
@@ -363,6 +363,7 @@ static int gpst_parse_config_xml(struct openconnect_info *vpninfo, xmlNode *xml_
 	for (xml_node = xml_node->children; xml_node; xml_node=xml_node->next) {
 		xmlnode_get_text(xml_node, "ip-address", &vpninfo->ip_info.addr);
 		xmlnode_get_text(xml_node, "netmask", &vpninfo->ip_info.netmask);
+		xmlnode_get_text(xml_node, "gw-address", &vpninfo->ip_info.gateway_addr_gp);
 
 		if (!xmlnode_get_text(xml_node, "mtu", &s)) {
 			vpninfo->ip_info.mtu = atoi(s);

--- a/gpst.c
+++ b/gpst.c
@@ -354,6 +354,8 @@ static int gpst_parse_config_xml(struct openconnect_info *vpninfo, xmlNode *xml_
 	vpninfo->ip_info.addr = vpninfo->ip_info.netmask = NULL;
 	vpninfo->ip_info.addr6 = vpninfo->ip_info.netmask6 = NULL;
 	vpninfo->ip_info.domain = NULL;
+	vpninfo->ip_info.mtu = 0;
+	vpninfo->esp_magic = inet_addr(vpninfo->ip_info.gateway_addr);
 
 	for (ii = 0; ii < 3; ii++)
 		vpninfo->ip_info.dns[ii] = vpninfo->ip_info.nbns[ii] = NULL;
@@ -363,10 +365,16 @@ static int gpst_parse_config_xml(struct openconnect_info *vpninfo, xmlNode *xml_
 	for (xml_node = xml_node->children; xml_node; xml_node=xml_node->next) {
 		xmlnode_get_text(xml_node, "ip-address", &vpninfo->ip_info.addr);
 		xmlnode_get_text(xml_node, "netmask", &vpninfo->ip_info.netmask);
-		xmlnode_get_text(xml_node, "gw-address", &vpninfo->ip_info.gateway_addr_gp);
 
 		if (!xmlnode_get_text(xml_node, "mtu", &s)) {
 			vpninfo->ip_info.mtu = atoi(s);
+			free((void *)s);
+		} else if (!xmlnode_get_text(xml_node, "gw-address", &s)) {
+			/* As remarked in oncp.c, "this is a tunnel; having a
+			 * gateway is meaningless." See esp_send_probes_gp for the
+			 * gory details of what this field actually means.
+			 */
+			vpninfo->esp_magic = inet_addr(s);
 			free((void *)s);
 		} else if (xmlnode_is_named(xml_node, "dns")) {
 			for (ii=0, member = xml_node->children; member && ii<3; member=member->next)

--- a/openconnect-internal.h
+++ b/openconnect-internal.h
@@ -372,6 +372,7 @@ struct openconnect_info {
 	int old_esp_maxseq;
 	struct esp esp_in[2];
 	struct esp esp_out;
+	in_addr_t esp_magic; /* GlobalProtect magic ping address (network-endian) */
 
 	int tncc_fd; /* For Juniper TNCC */
 	const char *csd_xmltag;

--- a/openconnect.h
+++ b/openconnect.h
@@ -282,6 +282,10 @@ struct oc_ip_info {
 	struct oc_split_include *split_includes;
 	struct oc_split_include *split_excludes;
 
+	/* Needed if the gateway address presented by the global protect
+	 * gateway portal is not the same as the actual portal. */
+	const char *gateway_addr_gp;
+
 	/* The elements above this line come from server-provided CSTP headers,
 	 * so they should be handled with caution.  gateway_addr is generated
 	 * locally from getnameinfo(). */

--- a/openconnect.h
+++ b/openconnect.h
@@ -282,10 +282,6 @@ struct oc_ip_info {
 	struct oc_split_include *split_includes;
 	struct oc_split_include *split_excludes;
 
-	/* Needed if the gateway address presented by the global protect
-	 * gateway portal is not the same as the actual portal. */
-	const char *gateway_addr_gp;
-
 	/* The elements above this line come from server-provided CSTP headers,
 	 * so they should be handled with caution.  gateway_addr is generated
 	 * locally from getnameinfo(). */


### PR DESCRIPTION
Although this is a small patch, I'm sure it took a lot of wild-goose-chasing by @patchon. Very nice work. (See #23 for more discussion.)

The GP XML config contains a field called `<gw-address>`. Until now, I've never seen it contain a value _other than_ the external IP address of the VPN gateway. So I ignored it, because having a "gateway" for a tunnel makes no sense (as @dwmw2 observed in `oncp.c` as well).

However, it turns out that for some VPNs, this field contains a different IP address; the "magic ping" packets used to initiate and maintain the ESP connection must be sent to this address.

This patch captures this IP address from the XML config, uses it appropriately in the magic ping packets, and adds some comments:

```c
	/* The GlobalProtect VPN initiates and maintains the ESP connection
	 * using specially-crafted ICMP ("ping") packets.
	 *

         ...

	 * 2) The ping packets are addressed to the IP supplied in the
	 *    config XML as as <gw-address>. In most cases, this is the
	 *    same as the *external* IP address of the VPN gateway
	 *    (vpninfo->ip_info.gateway_addr), but in some cases it is a
	 *    separate address.
	 *
	 *    Don't blame me. I didn't design this.
 	 */
```