### PR TITLE
Add PKGBUILD for Arch makepkg

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,26 @@
+pkgname=openconnect
+pkgver=7.08
+pkgrel=1
+epoch=1
+pkgdesc="Open client for Cisco AnyConnect VPN"
+arch=('i686' 'x86_64')
+license=('LGPL2.1')
+url="http://www.infradead.org/openconnect.html"
+depends=('libxml2' 'gnutls' 'libproxy' 'vpnc' 'krb5' 'lz4' 'pcsclite')
+makedepends=('intltool' 'python2')
+options=('!emptydirs')
+source=(ftp://ftp.infradead.org/pub/$pkgname/$pkgname-$pkgver.tar.gz)
+md5sums=('ca2ca1f61b8515879b481dcf6ed4366b')
+
+build() {
+  cd $pkgname-$pkgver
+  PYTHON=/usr/bin/python2 ./configure --prefix=/usr \
+      --sbindir=/usr/bin \
+      --disable-static
+  make
+}
+
+package() {
+  cd $pkgname-$pkgver
+  make DESTDIR="$pkgdir" install
+}


### PR DESCRIPTION
Any chance it would be possible to add a PKGBUILD file so that the repo can be easily built using Arch Linux?

It's a straight up copy from the official PKGBUILD file for openconnect:
https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/openconnect