### PR TITLE
Add 'gpmac' as option in --os

### DIFF
--- a/gpst.c
+++ b/gpst.c
@@ -445,6 +445,8 @@ static int gpst_parse_config_xml(struct openconnect_info *vpninfo, xmlNode *xml_
 					else if (xmlnode_is_named(member, "ekey-s2c"))		get_key_bits(member, vpninfo->esp_in[c].enc_key);
 					else if (xmlnode_is_named(member, "akey-c2s"))		get_key_bits(member, vpninfo->esp_out.hmac_key);
 					else if (xmlnode_is_named(member, "akey-s2c"))		get_key_bits(member, vpninfo->esp_in[c].hmac_key);
+					else if (!xmlnode_get_text(member, "ipsec-mode", &s) && strcmp(s, "esp-tunnel"))
+						vpn_progress(vpninfo, PRG_ERR, _("GlobalProtect config sent ipsec-mode=%s (expected esp-tunnel)\n"));
 					free((void *)s);
 				}
 				if (setup_esp_keys(vpninfo, 0))

--- a/library.c
+++ b/library.c
@@ -258,6 +258,10 @@ int openconnect_set_reported_os(struct openconnect_info *vpninfo,
 		vpninfo->csd_nostub = 1;
 	} else if (!strcmp(os, "win"))
 		vpninfo->csd_xmltag = "csd";
+	else if (!strcmp(os, "gpmac")){
+		os = "Apple Mac OS X 10.0.0";
+                vpninfo->csd_xmltag = "Apple Mac OS X 10.0.0";
+	}
 	else
 		return -EINVAL;
 


### PR DESCRIPTION
The --os option for mac needs to be Apple Mac OS X <some version> in order to be accepted by PaloAlto's Gateway. the option "gpmac" gives you that choice.