### PR TITLE
Added compatible Apple Mac OSX OS as 'gpmac'

### DIFF
--- a/library.c
+++ b/library.c
@@ -258,6 +258,10 @@ int openconnect_set_reported_os(struct openconnect_info *vpninfo,
 		vpninfo->csd_nostub = 1;
 	} else if (!strcmp(os, "win"))
 		vpninfo->csd_xmltag = "csd";
+	else if (!strcmp(os, "gpmac")){
+		os = "Apple Mac OS X 10.11.0";
+		vpninfo->csd_xmltag = "Apple Mac OS X 10.11.0";
+	}
 	else
 		return -EINVAL;
 


### PR DESCRIPTION
GlobalProtect reports a Mac OS X computer the following way: 

Apple Mac OS X <version>

I've added a recent version of Mac OS X: Apple Mac OS X 10.11.0

This tells GlobalProtect that the computer that is connecting is a Mac, therefore enabling HIP controls for Mac.