### PR TITLE
Add support for portal-userauthcookie authentication

### DIFF
--- a/auth-globalprotect.c
+++ b/auth-globalprotect.c
@@ -335,6 +335,7 @@ static int gpst_login(struct openconnect_info *vpninfo, int portal)
 		if (form->auth_id && form->auth_id[0]!='_')
 			append_opt(request_body, "inputStr", form->auth_id);
 		append_form_opts(vpninfo, form, request_body);
+		append_opt(request_body, "portal-userauthcookie", vpninfo->portal_userauthcookie);
 		if ((result = buf_error(request_body)))
 			goto out;
 

--- a/library.c
+++ b/library.c
@@ -89,6 +89,7 @@ struct openconnect_info *openconnect_vpninfo_new(const char *useragent,
 	vpninfo->proxy_auth[AUTH_TYPE_BASIC].state = AUTH_DEFAULT_DISABLED;
 	vpninfo->http_auth[AUTH_TYPE_BASIC].state = AUTH_DEFAULT_DISABLED;
 	openconnect_set_reported_os(vpninfo, NULL);
+	vpninfo->portal_userauthcookie = NULL;
 
 	if (!vpninfo->localname || !vpninfo->useragent)
 		goto err;

--- a/main.c
+++ b/main.c
@@ -189,6 +189,7 @@ enum {
 	OPT_PROTOCOL,
 	OPT_PASSTOS,
 	OPT_REQUEST_IP,
+	OPT_PORTAL_USERAUTHCOOKIE,
 };
 
 #ifdef __sun__
@@ -271,6 +272,7 @@ static const struct option long_options[] = {
 	OPTION("no-system-trust", 0, OPT_NO_SYSTEM_TRUST),
 	OPTION("protocol", 1, OPT_PROTOCOL),
 	OPTION("request-ip", 1, OPT_REQUEST_IP),
+	OPTION("userauthcookie", 1, OPT_PORTAL_USERAUTHCOOKIE),
 #ifdef OPENCONNECT_GNUTLS
 	OPTION("gnutls-debug", 1, OPT_GNUTLS_DEBUG),
 #endif
@@ -863,6 +865,7 @@ static void usage(void)
 	printf("      --os=STRING                 %s\n", _("OS type (linux,linux-64,win,...) to report"));
 	printf("      --dtls-local-port=PORT      %s\n", _("Set local port for DTLS datagrams"));
 	printf("      --request-ip=IP             %s\n", _("Request a specific IPv4 address"));
+	printf("      --userauthcookie=STRING     %s\n", _("Use portal user authentication cookie"));
 	print_supported_protocols_usage();
 
 	printf("\n");
@@ -1275,6 +1278,9 @@ int main(int argc, char **argv)
 			break;
 		case OPT_REQUEST_IP:
 			vpninfo->ip_info.addr = keep_config_arg();
+			break;
+		case OPT_PORTAL_USERAUTHCOOKIE:
+			vpninfo->portal_userauthcookie = dup_config_arg();
 			break;
 		case 'C':
 			vpninfo->cookie = dup_config_arg();
@@ -1992,7 +1998,9 @@ static int process_auth_form_cb(void *_vpninfo,
 			empty = 0;
 
 		} else if (opt->type == OC_FORM_OPT_PASSWORD) {
-			if (password &&
+			if (vpninfo->portal_userauthcookie) {
+				opt->_value = strdup("");
+			} else if (password &&
 			    (!strcmp(opt->name, "password") || opt->flags & OC_FORM_OPT_FILL_PASSWORD)) {
 				opt->_value = password;
 				password = NULL;

--- a/openconnect-internal.h
+++ b/openconnect-internal.h
@@ -642,6 +642,7 @@ struct openconnect_info {
 
 	int is_dyndns; /* Attempt to redo DNS lookup on each CSTP reconnect */
 	char *useragent;
+	char *portal_userauthcookie;
 
 	const char *quit_reason;
 


### PR DESCRIPTION
This patch adds new authentication mechanism (via `portal-userauthcookie`). This is required for different types of third-party integrations. I have tested this with OKTA (okta.com) integration. Was able to successfully use GlobalProtect VPN on FreeBSD and MacOS X, even with 2FA.

Basically, there is a "authentication dance" with Global Protect and OKTA, which results in `portal-userauthcookie`, which is used instead of `password`, i.e., password is sent empty. Therefore, I use my python script to do the dance and just pass the `portal-userauthcookie` to `openconnect` and everything is working fine.

Simplified, "authentication dance" flow with OKTA is like this:
1) send request to GP's `/global-protect/prelogin.esp`; retrieve `saml-auth-method` and `saml-request`
2) send request to OKTA URL (retrieved in previous step's `saml-request`); retrieve "redirect url" in response
4) authenticate with OKTA's `/api/v1/authn` (and if necessary then also with additional 2FA in following request) and retrieve `sessionToken`
5) send request to OKTA's `/login/sessionCookieRedirect`, providing "redirect url" and `sessionToken`; retrieve `saml-username` and `prelogin-cookie`
6) send request to GP's `/global-protect/getconfig.esp` with `saml-username` and `prelogin-cookie`; retrieve `portal-userauthcookie`
7) use `portal-userauthcookie` with openconnect

You can see the specific details of "authentication dance" by looking at python script in:
https://github.com/arthepsy/pan-globalprotect-okta