### PR TITLE
Fixes linking ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ $ git checkout globalprotect
 $ ./autogen.sh
 $ ./configure
 $ make
-$ make install
+$ sudo make install
+$ sudo ldconfig
 ```
 
 ### Building on the Mac


### PR DESCRIPTION
On vagrant ubuntu 16.04 (bento/ubuntu-16.04) was getting following error:

```
root@vagrant:/home/vagrant/openconnect# openconnect  
openconnect: error while loading shared libraries: libopenconnect.so.5: cannot open shared object file: No such file or directory
```
