### PR TITLE
append multiple search domains to CISCO_DEF_DOMAIN

### DIFF
--- a/gpst.c
+++ b/gpst.c
@@ -517,11 +517,16 @@ static int gpst_parse_config_xml(struct openconnect_info *vpninfo, xmlNode *xml_
 				if (!xmlnode_get_text(member, "member", &s))
 					vpninfo->ip_info.nbns[ii++] = add_option(vpninfo, "WINS", s);
 		} else if (xmlnode_is_named(xml_node, "dns-suffix")) {
-			for (ii=0, member = xml_node->children; member && ii<1; member=member->next)
+			FILE *stream;
+			char *buf;
+			size_t len;
+			stream = open_memstream(&buf, &len);
+			for (member = xml_node->children; member; member=member->next)
 				if (!xmlnode_get_text(member, "member", &s)) {
-					vpninfo->ip_info.domain = add_option(vpninfo, "search", s);
-					ii++;
+					fprintf(stream, "%s ", s);
 				}
+			fclose(stream);
+			vpninfo->ip_info.domain = add_option(vpninfo, "search", buf);
 		} else if (xmlnode_is_named(xml_node, "access-routes")) {
 			for (member = xml_node->children; member; member=member->next) {
 				if (!xmlnode_get_text(member, "member", &s)) {


### PR DESCRIPTION
It looks like this was an old issue (https://github.com/dlenski/openconnect/issues/40) that never got resolved. Reading upstream mailing list thread (http://lists.infradead.org/pipermail/openconnect-devel/2017-August/004452.html), it looks like setting CISCO_SPLIT_DNS is not correct thing to do and instead should use CISCO_DEF_DOMAIN.

This patch walks through the "dns-suffix" xml members and creates a space-separated string containing all of them. I'm honestly not sure if the way I did it is optimal since I'm brand-new to C. That being said, it does seem to work exactly as expected when used with upstream vpnc-script (http://git.infradead.org/users/dwmw2/vpnc-scripts.git/blob_plain/HEAD:/vpnc-script)