### PR TITLE
include instructions for install via nix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,28 @@ $ docker run -ti --rm --privileged --net=host openconnect
 Leave that container running, open another terminal, and you'll see a
 newly created tun connection for your whole system to use.
 
+### Nix
+
+Installation via nix is a one-liner, and the binary will most likely be
+cached (i.e. no build from source will be necessary).
+
+On non-NixOS machines:
+```sh
+$ nix-env -iA nixpkgs.openconnect_pa
+```
+
+On NixOS:
+```sh
+$ nix-env -iA nixos.openconnect_pa
+```
+
+One can also drop into a shell with `openconnect` available:
+```sh
+$ nix-shell -p openconnect_pa
+```
+When you exit this shell, `openconnect` will no longer be available.
+This is useful if you wish to avoid a global install.
+
 ## Connecting to a GlobalProtect VPN
 
 Run openconnect like this to test it with your GlobalProtect VPN


### PR DESCRIPTION
This afternoon I added this fork of openconnect to nixpkgs (https://github.com/NixOS/nixpkgs).

This offers users another mode of installation that doesn't require any fiddling with dependencies, and the build artifact of this fork will be cached, so users won't have to actually build anything.

The PR that added it is https://github.com/NixOS/nixpkgs/pull/50513.

I verified that at least the following usage works:

```sh
openconnect --protocol=gp server.company.com --dump -vvv
```

I was authenticated, prompted by DUO for confirmation, and then able to ssh into a machine to which i would otherwise not have access on my company's network. I include that as an example of a test of functionality that I performed, though I would like to add that it is unlikely the functionality differs from that of `master`, since the version in `nixpkgs` just builds and installs master to /nix/store.

Thanks for keeping up with this greatly useful project!