### PR TITLE
Decrease docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,31 @@
-FROM debian:9-slim as builder
+FROM alpine:edge
+ENV BUILD_ENV="file \
+                g++ \
+                gnutls-dev \
+                libnl3-dev \
+                libseccomp-dev \
+                linux-pam-dev\
+                linux-headers \
+                lz4-dev \
+                make \
+                readline-dev \
+                vpnc \
+                autoconf \
+                automake \
+                libtool \
+                libxml2-dev \
+                git"
+COPY . /openconnect
 WORKDIR /openconnect
-RUN apt update \
-    && apt install -y  \
-	build-essential \
-	gettext \
-	autoconf \
-	automake \
-	libproxy-dev \
-	libxml2-dev \
-	libtool \
-	vpnc-scripts \
-	pkg-config \
-	libgnutls28-dev \
-	git \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-ADD . .
-RUN ./autogen.sh
-RUN ./configure
-RUN make
-
-#FROM debian:9-slim
-#WORKDIR /openconnect
-#COPY --from=builder /openconnect .
-#RUN make install
-#RUN ldconfig
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
+    && apk add --no-cache --virtual .build-deps ${BUILD_ENV} \
+    && ./autogen.sh \
+    && ./configure \
+    && make \
+    && make install \
+    && ldconfig . -v \
+    && apk del .build-deps \
+    && rm -rf /openconnect \
+    && apk add --no-cache gnutls libxml2 lz4-dev gettext ca-certificates vpnc
+WORKDIR /
+ENTRYPOINT ["/usr/local/sbin/openconnect"]


### PR DESCRIPTION
* replace debian with alpine (45.4MB)

As an idea I can replace alpine with `scratch` if it's possible to statically link openconnect.
In general I don't think it really useful to have anything else in container as I would run it like: 
```
docker run --privileged --net=host -it openconnect --user=username --protocol=gp vpn.example.com
```
and for debug purpose it's always possible to replace `scratch` back with `alpine`.