### PR TITLE
Always send client cert

### DIFF
--- a/gnutls.c
+++ b/gnutls.c
@@ -2162,7 +2162,7 @@ int openconnect_open_https(struct openconnect_info *vpninfo)
 			}
 		}
 	}
-	gnutls_init(&vpninfo->https_sess, GNUTLS_CLIENT);
+	gnutls_init(&vpninfo->https_sess, GNUTLS_CLIENT|GNUTLS_FORCE_CLIENT_CERT);
 	gnutls_session_set_ptr(vpninfo->https_sess, (void *) vpninfo);
 	/*
 	 * For versions of GnuTLS older than 3.2.9, we try to avoid long


### PR DESCRIPTION
TLS servers may request a certificate from the client. This request includes a list of 0 or more acceptable issuer DNs. The client may use this list to determine which certificate to send. GnuTLS's default behavior is to not send a client certificate if there is no match. However, we generally always have a specific certificate specified, so we just want to send that regardless.