### PR TITLE
changed spelling of one of the build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Under Debian-based or Ubuntu-based distributions, this should install the requir
 
 ```sh
 $ sudo apt-get install build-essential gettext autoconf automake libproxy-dev libxml2-dev libtool vpnc-scripts pkg-config \
-                       libgnutls-dev # may be named libgnutls28-dev on some recent Debian/Ubuntu-based distros
+                       libgnutils-dev # may be named libgnutils28-dev on some recent Debian/Ubuntu-based distros
 
 ```
 


### PR DESCRIPTION
libgnutils was spelled like libgnutls and generating errors.